### PR TITLE
Feature/main window ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,19 @@
 
 ### Meta
 
+### Restore Application To Fresh Install
+
+Here’s how to start over with untouched preferences and default window sizes:
+
+1. Quit Screenshoddy if it’s running.
+
+2. Delete the application support folder. On the command line: `rm -rf ~/Library/Application\ Support/Screenshoddy/`
+
+3. Delete the preferences.  On the command line do: `defaults delete com.geofcrowl.Screenshoddy` and then `killall cfprefsd`
+
+4. Launch Screenshody or build and run. All the preferences and window sizes should be set back to the defaults.
+
+
 ### Contributing
 
 - Fork it

--- a/Screenshoddy.xcodeproj/project.pbxproj
+++ b/Screenshoddy.xcodeproj/project.pbxproj
@@ -68,7 +68,6 @@
 				3C1F40B5245DF120006554AA /* Assets.xcassets */,
 				3C1F40C6245E2327006554AA /* Globals.swift */,
 				3C1F40B7245DF120006554AA /* MainMenu.xib */,
-				3C58CAA0245F4F5A00AC3444 /* README.md */,
 				3C1F40BA245DF120006554AA /* Info.plist */,
 				3C1F40BB245DF120006554AA /* Screenshoddy.entitlements */,
 			);
@@ -297,6 +296,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Screenshoddy/Screenshoddy.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_TEAM = C62KGZ35B8;
@@ -317,6 +317,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Screenshoddy/Screenshoddy.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_TEAM = C62KGZ35B8;

--- a/Screenshoddy/AppDelegate.swift
+++ b/Screenshoddy/AppDelegate.swift
@@ -27,6 +27,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         return true
     }
 
-
+    @IBAction func showMainWindow(_ sender: Any) {
+        screenshotWC.showWindow(self)
+    }
+    
 }
 

--- a/Screenshoddy/Base.lproj/MainMenu.xib
+++ b/Screenshoddy/Base.lproj/MainMenu.xib
@@ -10,7 +10,7 @@
             </connections>
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
-        <customObject id="-3" userLabel="Application"/>
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModule="Screenshoddy" customModuleProvider="target"/>
         <customObject id="YLy-65-1bz" customClass="NSFontManager"/>
         <menu title="Main Menu" systemMenu="main" id="AYu-sK-qS6">
@@ -651,6 +651,13 @@
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="eu3-7i-yIM"/>
+                            <menuItem title="Show Window" id="n1N-f4-aXs">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="showMainWindow:" target="Voe-Tx-rLC" id="hzf-nA-vNU"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="mMy-Wy-E1e"/>
                             <menuItem title="Bring All to Front" id="LE2-aR-0XJ">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>

--- a/Screenshoddy/UI/ScreenshotView.swift
+++ b/Screenshoddy/UI/ScreenshotView.swift
@@ -19,6 +19,9 @@ class ScreenshotView: NSView {
         
         super.init(frame: frameRect)
         
+        wantsLayer = true
+        layer?.backgroundColor = NSColor.underPageBackgroundColor.cgColor
+        
         addSubview(messageTextView)
         messageTextView.string = "No image in pasteboard"
         messageTextView.isEditable = false
@@ -29,7 +32,6 @@ class ScreenshotView: NSView {
         messageTextView.textColor = .secondaryLabelColor
         
         addSubview(imageView)
-//        imageView.image = NSImage(named: NSImage.Name("test"))
         imageView.allowsCutCopyPaste = true
         
         addSubview(controlView)

--- a/Screenshoddy/UI/ScreenshotWindow.swift
+++ b/Screenshoddy/UI/ScreenshotWindow.swift
@@ -34,6 +34,7 @@ class ScreenshotWindow: NSWindow {
         
         contentViewController = screenshotVC
         autorecalculatesKeyViewLoop = true
+        isRestorable = true
         
         minSize = NSSize(width: 250, height: 250)
         delegate = self

--- a/Screenshoddy/UI/ScreenshotWindow.swift
+++ b/Screenshoddy/UI/ScreenshotWindow.swift
@@ -28,8 +28,6 @@ class ScreenshotWindow: NSWindow {
         
         super.init(contentRect: contentRect, styleMask: style, backing: backingStoreType, defer: flag)
         
-//        title = "Screenshoddy"
-//        titleVisibility = .hidden
         titlebarAppearsTransparent = true
         
         contentViewController = screenshotVC

--- a/Screenshoddy/UI/ScreenshotWindow.swift
+++ b/Screenshoddy/UI/ScreenshotWindow.swift
@@ -28,7 +28,8 @@ class ScreenshotWindow: NSWindow {
         
         super.init(contentRect: contentRect, styleMask: style, backing: backingStoreType, defer: flag)
         
-        titlebarAppearsTransparent = true
+        title = "Screenshoddy"
+//        titlebarAppearsTransparent = true
         
         contentViewController = screenshotVC
         autorecalculatesKeyViewLoop = true

--- a/Screenshoddy/UI/ScreenshotWindow.swift
+++ b/Screenshoddy/UI/ScreenshotWindow.swift
@@ -35,7 +35,6 @@ class ScreenshotWindow: NSWindow {
         isRestorable = true
         
         minSize = NSSize(width: 250, height: 250)
-        delegate = self
     }
     
 }


### PR DESCRIPTION
Improve main window ui and appearance.

- Added [.underPageBackgroundColor](https://developer.apple.com/documentation/appkit/nscolor/1534707-underpagebackgroundcolor) to main view. I think that's the appropriate background color behind the screenshot according to: https://developer.apple.com/design/human-interface-guidelines/macos/visual-design/color/

- Re-added titlebar. What do you think about this @zachwood ? I don't think I can make up my mind. Haha…

<img width="585" alt="Screen Shot 2020-05-04 at 8 41 32 PM" src="https://user-images.githubusercontent.com/354758/81030924-cceb0d00-8e47-11ea-80d7-406339c24ad0.png">
<img width="585" alt="Screen Shot 2020-05-04 at 8 41 13 PM" src="https://user-images.githubusercontent.com/354758/81030926-d07e9400-8e47-11ea-8f43-3f30367a8a8b.png">
